### PR TITLE
Enable "gzip" compression

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/HttpRequestFactory.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/HttpRequestFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2015 Numenta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -94,17 +95,9 @@ class HttpRequestFactory {
             }
         }
 
-        /*
-         * Amazon DynamoDB sets CRC32 checksum in the header 'x-amz-crc32'. If
-         * compression is turned on, then the checksum is calculated on the
-         * compressed data. On the client side, compression is handled by the
-         * HTTP client. In most cases, the client doesn't have access to
-         * compressed data, so there is no way to compute the checksum of
-         * compressed data unless the client compress it. To get around it,
-         * compression is turned off explicitly.
-         */
+        // Enable "gzip" compression by default
         if (request.getHeaders().get("Accept-Encoding") == null) {
-            request.addHeader("Accept-Encoding", "identity");
+            request.addHeader("Accept-Encoding", "gzip");
         }
 
         Map<String, String> headers = new HashMap<String, String>();


### PR DESCRIPTION
In order to lower the user's mobile data usage, we should default to a compressed stream instead of uncompressed one.

If the client added an "Accept-Encoding: gzip" header field to the request then the client is responsible for also decompressing the response stream. Android 'HttpURLConnection' is respecting that contract by only adding automatically compression/decompression to the response when the client does not explicit specify the encoding. See https://android.googlesource.com/platform/libcore/+/jb-release/luni/src/main/java/libcore/net/http/HttpEngine.java

This patch will add "Accept-Encoding: gzip" header field to the request by default, use the compressed stream to calculate the CRC32 and use the uncompressed stream to parse the JSON response.