### PR TITLE
updated the error message to return what the API responded with

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -237,8 +237,7 @@ class ApiClientHandler implements InvocationHandler {
             }
         } else {
             String error = content == null ? "NONE" : IOUtils.toString(content);
-            ApiClientException ase = new ApiClientException("Service returned code: "
-                    + code + ", error: " + error);
+            ApiClientException ase = new ApiClientException(error);
             ase.setStatusCode(response.getStatusCode());
             ase.setServiceName(apiName);
             String requestId = response.getHeaders().get("x-amzn-RequestId");


### PR DESCRIPTION
Adding these logging strings is unnecessary, and removing them makes it possible to deal with error responses returned by API Gateway with unneeded String parsing. 

Anyone wanting the logging information that was originally there can use the existing ApiClientException.getMessage() to get back that exact information and more.

The usage can then become:
```java
    // 2XX response
    try {
        mcClient.offersPut(offer);
        // ... whatever you need to do
    }
    // 4XX or 5XX response
    catch (ApiClientException e) {
        String errorMessage = e.getErrorMessage();
        // ... do whatever you need (pass off to Jackson or Gson, parse the string, whatever)
        // but now errorMessage is the String that API Gateway sent back!
    }
```

This would also provide parity with the iOS and JS SDKs.