### PR TITLE
Fix issue with Lambda with no input args

### DIFF
--- a/aws-android-sdk-lambda/src/main/java/com/amazonaws/mobileconnectors/lambdainvoker/LambdaInvocationHandler.java
+++ b/aws-android-sdk-lambda/src/main/java/com/amazonaws/mobileconnectors/lambdainvoker/LambdaInvocationHandler.java
@@ -54,7 +54,8 @@ class LambdaInvocationHandler implements InvocationHandler {
             throws Throwable {
         validateInterfaceMethod(method, args);
 
-        InvokeRequest invokeRequest = buildInvokeRequest(method, args == null ? null : args[0]);
+        final Object buildArg = (args == null || args.length == 0) ? null : args[0];
+        InvokeRequest invokeRequest = buildInvokeRequest(method, buildArg);
         InvokeResult invokeResult = lambda.invoke(invokeRequest);
 
         return processInvokeResult(method, invokeResult);


### PR DESCRIPTION
Fixes #79 
This adds a check to make sure that if Lambda method has no input arguments
it won't throw IndexOutOfBoundsException