### PR TITLE
Replace StandardCharsets (min SDK 19) with Charset.forName()

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
@@ -77,7 +77,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.VerifyUserAttributeR
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -101,6 +101,8 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public class CognitoUser {
     private final String TAG = "CognitoUser";
+
+    private static final Charset CHARSET = Charset.forName("UTF-8");
 
     /**
      * Application context.
@@ -1815,14 +1817,14 @@ public class CognitoUser {
             Mac mac = Mac.getInstance("HmacSHA256");
             SecretKeySpec keySpec = new SecretKeySpec(key, "HmacSHA256");
             mac.init(keySpec);
-            mac.update(pool.getUserPoolId().split("_", 2)[1].getBytes(StandardCharsets.UTF_8));
-            mac.update(usernameInternal.getBytes(StandardCharsets.UTF_8));
+            mac.update(pool.getUserPoolId().split("_", 2)[1].getBytes(CHARSET));
+            mac.update(usernameInternal.getBytes(CHARSET));
             mac.update(authDetails.getSecretBlock().array());
 
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat("EEE MMM d HH:mm:ss z yyyy");
             simpleDateFormat.setTimeZone(new SimpleTimeZone(SimpleTimeZone.UTC_TIME, "UTC"));
             String dateString = simpleDateFormat.format(timestamp);
-            byte[] dateBytes = dateString.getBytes(StandardCharsets.UTF_8);
+            byte[] dateBytes = dateString.getBytes(CHARSET);
 
             hmac = mac.doFinal(dateBytes);
         } catch (NoSuchAlgorithmException e) {
@@ -1939,10 +1941,10 @@ public class CognitoUser {
 
             // x = H(salt | H(poolName | userId | ":" | password))
             messageDigest.reset();
-            messageDigest.update(poolName.getBytes(StandardCharsets.UTF_8));
-            messageDigest.update(userId.getBytes(StandardCharsets.UTF_8));
-            messageDigest.update(":".getBytes(StandardCharsets.UTF_8));
-            byte [] userIdHash = messageDigest.digest(userPassword.getBytes(StandardCharsets.UTF_8));
+            messageDigest.update(poolName.getBytes(CHARSET));
+            messageDigest.update(userId.getBytes(CHARSET));
+            messageDigest.update(":".getBytes(CHARSET));
+            byte [] userIdHash = messageDigest.digest(userPassword.getBytes(CHARSET));
 
             messageDigest.reset();
             messageDigest.update(salt.toByteArray());

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoSecretHash.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoSecretHash.java
@@ -21,7 +21,7 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.Cognito
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.CognitoParameterInvalidException;
 import com.amazonaws.util.Base64;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -31,6 +31,8 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public final class CognitoSecretHash {
     private final static String HMAC_SHA_256 = "HmacSHA256";
+
+    private static final Charset CHARSET = Charset.forName("UTF-8");
 
     /**
      * Generates secret hash. Uses HMAC SHA256.
@@ -55,14 +57,14 @@ public final class CognitoSecretHash {
             return null;
         }
 
-        SecretKeySpec signingKey = new SecretKeySpec(clientSecret.getBytes(StandardCharsets.UTF_8),
+        SecretKeySpec signingKey = new SecretKeySpec(clientSecret.getBytes(CHARSET),
                 HMAC_SHA_256);
 
         try {
             Mac mac = Mac.getInstance(HMAC_SHA_256);
             mac.init(signingKey);
-            mac.update(userId.getBytes(StandardCharsets.UTF_8));
-            byte[] rawHmac = mac.doFinal(clientId.getBytes(StandardCharsets.UTF_8));
+            mac.update(userId.getBytes(CHARSET));
+            byte[] rawHmac = mac.doFinal(clientId.getBytes(CHARSET));
             return  new String(Base64.encode(rawHmac));
         } catch (Exception e) {
             throw new CognitoInternalErrorException("errors in HMAC calculation");


### PR DESCRIPTION
StandardCharsets has been added in Java 1.7 and Android SDK 19 and thus
cause a java.lang.NoClassDefFoundError in Android 18 and below.

Should resolve issue #129