### PR TITLE
Expose Client Configuration in API Factory and prevent user agent being overridden

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -115,7 +115,7 @@ public class ApiClientFactory {
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
                 new Class<?>[]{
-                        apiClass
+                    apiClass
                 }, handler);
         return apiClass.cast(proxy);
     }
@@ -164,7 +164,7 @@ public class ApiClientFactory {
      * Gets signer.
      *
      * @param serviceName service name
-     * @param region      region
+     * @param region region
      * @return signer
      */
     Signer getSigner(String region) {

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -123,15 +123,17 @@ public class ApiClientFactory {
     /**
      * Gets an invocation handler for the given API.
      *
-     * @param apiClass API class
+     * @param endpoint Request endpoint
+     * @param apiName API class name
      * @return an invocation handler
      */
     ApiClientHandler getHandler(String endpoint, String apiName) {
         Signer signer = provider == null ? null : getSigner(getRegion(endpoint));
 
-        ApiClientHandler handler = new ApiClientHandler(
-                endpoint, apiName, signer, provider, apiKey, clientConfiguration);
-        return handler;
+        // Ensure we always pass a configuration to the handler
+        ClientConfiguration configuration = (clientConfiguration == null) ? new ClientConfiguration() : clientConfiguration;
+
+        return new ApiClientHandler(endpoint, apiName, signer, provider, apiKey, configuration);
     }
 
     /**

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.apigateway;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWS4Signer;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.Signer;
@@ -38,6 +39,7 @@ public class ApiClientFactory {
     private String apiKey;
     private String regionOverride;
     private AWSCredentialsProvider provider;
+    private ClientConfiguration clientConfiguration;
 
     /**
      * Sets the endpoint of the APIs.
@@ -74,6 +76,17 @@ public class ApiClientFactory {
     }
 
     /**
+     * Specify the client configuration to use with this factory
+     *
+     * @param clientConfiguration Configuration to use
+     * @return the factory itself for chaining
+     */
+    public ApiClientFactory clientConfiguration(ClientConfiguration clientConfiguration) {
+        this.clientConfiguration = clientConfiguration;
+        return this;
+    }
+
+    /**
      * Sets the credentials provider, needed if APIs require authentication.
      *
      * @param provider an AWS credentials provider
@@ -101,8 +114,8 @@ public class ApiClientFactory {
         String apiName = getApiName(apiClass);
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
-                new Class<?>[] {
-                    apiClass
+                new Class<?>[]{
+                        apiClass
                 }, handler);
         return apiClass.cast(proxy);
     }
@@ -117,7 +130,7 @@ public class ApiClientFactory {
         Signer signer = provider == null ? null : getSigner(getRegion(endpoint));
 
         ApiClientHandler handler = new ApiClientHandler(
-                endpoint, apiName, signer, provider, apiKey);
+                endpoint, apiName, signer, provider, apiKey, clientConfiguration);
         return handler;
     }
 
@@ -149,7 +162,7 @@ public class ApiClientFactory {
      * Gets signer.
      *
      * @param serviceName service name
-     * @param region region
+     * @param region      region
      * @return signer
      */
     Signer getSigner(String region) {

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -114,7 +114,7 @@ public class ApiClientFactory {
         String apiName = getApiName(apiClass);
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
-                new Class<?>[]{
+                new Class<?>[] {
                     apiClass
                 }, handler);
         return apiClass.cast(proxy);

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -67,7 +67,7 @@ class ApiClientHandler implements InvocationHandler {
     private final ClientConfiguration clientConfiguration;
 
     ApiClientHandler(String endpoint, String apiName,
-                     Signer signer, AWSCredentialsProvider provider, String apiKey, ClientConfiguration clientConfiguration) {
+            Signer signer, AWSCredentialsProvider provider, String apiKey, ClientConfiguration clientConfiguration) {
         this.endpoint = endpoint;
         this.apiName = apiName;
         this.signer = signer;
@@ -140,7 +140,7 @@ class ApiClientHandler implements InvocationHandler {
      * Build a {@link Request} object for the given method.
      *
      * @param method method that annotated with {@link Operation}
-     * @param args   arguments of the method
+     * @param args arguments of the method
      * @return a {@link Request} object
      */
     Request<?> buildRequest(Method method, Object[] args) {
@@ -199,8 +199,8 @@ class ApiClientHandler implements InvocationHandler {
      * Process an argument annotated with {@link Parameter}.
      *
      * @param request request to be set
-     * @param p       annotation
-     * @param arg     argument
+     * @param p annotation
+     * @param arg argument
      */
     void processParameter(Request<?> request, Parameter p, Object arg) {
         String name = p.name();
@@ -234,7 +234,7 @@ class ApiClientHandler implements InvocationHandler {
      * none of GET, POST, PUT, DELETE, and HEAD, then it will be tunneled via
      * X-HTTP-Method-Override. Note that not all servers support this header.
      *
-     * @param request    request to be set
+     * @param request request to be set
      * @param httpMethod given http method
      * @param hasContent indicate whether the request has content body
      */
@@ -256,7 +256,7 @@ class ApiClientHandler implements InvocationHandler {
      * Converts response to method's declared returned object
      *
      * @param response http response
-     * @param method   method
+     * @param method method
      * @return object of method's declared returned type
      * @throws Throwable
      */

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -67,15 +67,15 @@ class ApiClientHandler implements InvocationHandler {
     private final ClientConfiguration clientConfiguration;
 
     ApiClientHandler(String endpoint, String apiName,
-            Signer signer, AWSCredentialsProvider provider, String apiKey) {
+                     Signer signer, AWSCredentialsProvider provider, String apiKey, ClientConfiguration clientConfiguration) {
         this.endpoint = endpoint;
         this.apiName = apiName;
         this.signer = signer;
         this.provider = provider;
         this.apiKey = apiKey;
+        this.clientConfiguration = clientConfiguration;
 
-        clientConfiguration = new ClientConfiguration();
-        client = new UrlHttpClient(clientConfiguration);
+        client = new UrlHttpClient(this.clientConfiguration);
         requestFactory = new HttpRequestFactory();
     }
 
@@ -84,8 +84,7 @@ class ApiClientHandler implements InvocationHandler {
             throws Throwable {
         Request<?> request = buildRequest(method, args);
 
-        ExecutionContext context = new ExecutionContext();
-        context.setContextUserAgent(apiName);
+        ExecutionContext context = executionContext(method, args);
         HttpRequest httpRequest = requestFactory.createHttpRequest(request, clientConfiguration,
                 context);
         HttpResponse response = client.execute(httpRequest);
@@ -94,10 +93,54 @@ class ApiClientHandler implements InvocationHandler {
     }
 
     /**
+     * Get the execution context for the given request. Check the method's parameter
+     * annotations and if no user agent header is set, use the execution context's header
+     * with {@link #apiName} as {@link ExecutionContext#contextUserAgent}.
+     *
+     * @param method method annotated with {@link Operation}
+     * @param args   arguments of the method
+     * @return The execution context for the given method
+     */
+    private ExecutionContext executionContext(Method method, Object[] args) {
+        ExecutionContext context = new ExecutionContext();
+
+        Annotation[][] annotations = method.getParameterAnnotations();
+        int length = annotations.length;
+        for (int i = 0; i < length; i++) {
+            if (annotations[i].length == 0) continue;
+
+            for (Annotation annotation : annotations[i]) {
+                if (annotation instanceof Parameter && isUserAgentHeader((Parameter) annotation, args[i])) {
+                    return context;
+                }
+            }
+        }
+
+        context.setContextUserAgent(apiName);
+        return context;
+    }
+
+    /**
+     * Check if the given parameter is a user agent and has a valid value. If the value
+     * is empty than we consider this as not valid.
+     *
+     * @param parameter Annotation in the argument
+     * @param arg       Argument to check
+     * @return True if it's the user agent header and it's value is not empty.
+     */
+    private boolean isUserAgentHeader(Parameter parameter, Object arg) {
+        String name = parameter.name();
+        String location = parameter.location();
+
+        return "header".equals(location) && "User-Agent".equals(name)
+                && !String.valueOf(arg).isEmpty();
+    }
+
+    /**
      * Build a {@link Request} object for the given method.
      *
      * @param method method that annotated with {@link Operation}
-     * @param args arguments of the method
+     * @param args   arguments of the method
      * @return a {@link Request} object
      */
     Request<?> buildRequest(Method method, Object[] args) {
@@ -156,8 +199,8 @@ class ApiClientHandler implements InvocationHandler {
      * Process an argument annotated with {@link Parameter}.
      *
      * @param request request to be set
-     * @param p annotation
-     * @param arg argument
+     * @param p       annotation
+     * @param arg     argument
      */
     void processParameter(Request<?> request, Parameter p, Object arg) {
         String name = p.name();
@@ -191,7 +234,7 @@ class ApiClientHandler implements InvocationHandler {
      * none of GET, POST, PUT, DELETE, and HEAD, then it will be tunneled via
      * X-HTTP-Method-Override. Note that not all servers support this header.
      *
-     * @param request request to be set
+     * @param request    request to be set
      * @param httpMethod given http method
      * @param hasContent indicate whether the request has content body
      */
@@ -213,7 +256,7 @@ class ApiClientHandler implements InvocationHandler {
      * Converts response to method's declared returned object
      *
      * @param response http response
-     * @param method method
+     * @param method   method
      * @return object of method's declared returned type
      * @throws Throwable
      */


### PR DESCRIPTION
We do a lot of client identification based on user agent in our api requests. Unfortunately the sdk was overriding this.

This PR prevents this so that if there's a parameter present in the client interface that sets the user agent, then we don't override it. In other words, if an interface is defined as such:

```java
    SomeObject get(@Parameter(name = "User-Agent", location = "header") String userAgent);
```

Then the user agent is not overridden.

The PR also exposes the ``ClientConfiguration`` in the ``ApiClientFactory`` to allow for higher flexibility. In our use case we use it to set the user agent for all clients by default and have the above way to specify it per call.

I'm not sure how to handle versioning here, let me know if you'd like me to bump it.