### PR TITLE
Expose client configuration through api factory

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -115,7 +115,7 @@ public class ApiClientFactory {
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
                 new Class<?>[]{
-                        apiClass
+                    apiClass
                 }, handler);
         return apiClass.cast(proxy);
     }
@@ -164,7 +164,7 @@ public class ApiClientFactory {
      * Gets signer.
      *
      * @param serviceName service name
-     * @param region      region
+     * @param region region
      * @return signer
      */
     Signer getSigner(String region) {

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -123,15 +123,17 @@ public class ApiClientFactory {
     /**
      * Gets an invocation handler for the given API.
      *
-     * @param apiClass API class
+     * @param endpoint Request endpoint
+     * @param apiName API class name
      * @return an invocation handler
      */
     ApiClientHandler getHandler(String endpoint, String apiName) {
         Signer signer = provider == null ? null : getSigner(getRegion(endpoint));
 
-        ApiClientHandler handler = new ApiClientHandler(
-                endpoint, apiName, signer, provider, apiKey, clientConfiguration);
-        return handler;
+        // Ensure we always pass a configuration to the handler
+        ClientConfiguration configuration = (clientConfiguration == null) ? new ClientConfiguration() : clientConfiguration;
+
+        return new ApiClientHandler(endpoint, apiName, signer, provider, apiKey, configuration);
     }
 
     /**

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.apigateway;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWS4Signer;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.Signer;
@@ -38,6 +39,7 @@ public class ApiClientFactory {
     private String apiKey;
     private String regionOverride;
     private AWSCredentialsProvider provider;
+    private ClientConfiguration clientConfiguration;
 
     /**
      * Sets the endpoint of the APIs.
@@ -74,6 +76,17 @@ public class ApiClientFactory {
     }
 
     /**
+     * Specify the client configuration to use with this factory
+     *
+     * @param clientConfiguration Configuration to use
+     * @return the factory itself for chaining
+     */
+    public ApiClientFactory clientConfiguration(ClientConfiguration clientConfiguration) {
+        this.clientConfiguration = clientConfiguration;
+        return this;
+    }
+
+    /**
      * Sets the credentials provider, needed if APIs require authentication.
      *
      * @param provider an AWS credentials provider
@@ -101,8 +114,8 @@ public class ApiClientFactory {
         String apiName = getApiName(apiClass);
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
-                new Class<?>[] {
-                    apiClass
+                new Class<?>[]{
+                        apiClass
                 }, handler);
         return apiClass.cast(proxy);
     }
@@ -117,7 +130,7 @@ public class ApiClientFactory {
         Signer signer = provider == null ? null : getSigner(getRegion(endpoint));
 
         ApiClientHandler handler = new ApiClientHandler(
-                endpoint, apiName, signer, provider, apiKey);
+                endpoint, apiName, signer, provider, apiKey, clientConfiguration);
         return handler;
     }
 
@@ -149,7 +162,7 @@ public class ApiClientFactory {
      * Gets signer.
      *
      * @param serviceName service name
-     * @param region region
+     * @param region      region
      * @return signer
      */
     Signer getSigner(String region) {

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -114,7 +114,7 @@ public class ApiClientFactory {
         String apiName = getApiName(apiClass);
         ApiClientHandler handler = getHandler(endpoint, apiName);
         Object proxy = Proxy.newProxyInstance(apiClass.getClassLoader(),
-                new Class<?>[]{
+                new Class<?>[] {
                     apiClass
                 }, handler);
         return apiClass.cast(proxy);

--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -67,15 +67,15 @@ class ApiClientHandler implements InvocationHandler {
     private final ClientConfiguration clientConfiguration;
 
     ApiClientHandler(String endpoint, String apiName,
-            Signer signer, AWSCredentialsProvider provider, String apiKey) {
+            Signer signer, AWSCredentialsProvider provider, String apiKey, ClientConfiguration clientConfiguration) {
         this.endpoint = endpoint;
         this.apiName = apiName;
         this.signer = signer;
         this.provider = provider;
         this.apiKey = apiKey;
+        this.clientConfiguration = clientConfiguration;
 
-        clientConfiguration = new ClientConfiguration();
-        client = new UrlHttpClient(clientConfiguration);
+        client = new UrlHttpClient(this.clientConfiguration);
         requestFactory = new HttpRequestFactory();
     }
 


### PR DESCRIPTION
In our code base we found it very useful to expose the ``ClientConfiguration`` through the ``ApiClientFactory``. This let's us for example set the user agent for all our calls since we do a lot of client identification based on this header.

We'd like to propose this change. We didn't break the contract and respected the method chaining previously there. One can set the configuration as such:

```java
new ApiClientFactory()
                .clientConfiguration(clientConfiguration)
                .endpoint("some endpoint");
```

Thank you