### PR TITLE
Fix Cognito User Pools token refresh and failure handling

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserSession.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserSession.java
@@ -17,6 +17,7 @@
 
 package com.amazonaws.mobileconnectors.cognitoidentityprovider;
 
+import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.tokens.CognitoAccessToken;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.tokens.CognitoIdToken;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.tokens.CognitoRefreshToken;
@@ -27,6 +28,8 @@ import java.util.Date;
  * This wraps all Cognito tokens for a user.
  */
 public class CognitoUserSession {
+    /** Default threshold for refreshing session credentials */
+    public static final int DEFAULT_THRESHOLD_SECONDS = 500;
     /**
      * Cognito identity token.
      */
@@ -88,8 +91,8 @@ public class CognitoUserSession {
      * @return boolean to indicate if the access and id tokens have not expired.
      */
     public boolean isValid() {
-        Date currentTimeStamp = new Date();
-        
+        Date currentTimeStamp = new Date(System.currentTimeMillis()
+                - SDKGlobalConfiguration.getGlobalTimeOffset() * 1000);
         try {
             return (currentTimeStamp.before(idToken.getExpiration())
                     & currentTimeStamp.before(accessToken.getExpiration()));


### PR DESCRIPTION
Cognito User Pools token refresh was not working. As a result after 1 hour, the automatic token refresh was broken when getting a user pools session.
Also failures were not reported properly - not every failure is an authorization failure.
When non-authorization failures occur, the cached tokens should not be cleared. At a later point, the refresh token might still work to refresh the tokens.
Client clock skew has to be taken into account when looking at token validity.
Finally some offset from expiry point has to be considered (just like in CognitoCredentialsProvider) to make sure token doesn't expire between getSession() and using the session right after that.