### PR TITLE
Allow custom trust manager on client configuration

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -22,6 +22,8 @@ import com.amazonaws.util.VersionInfoUtils;
 
 import java.net.InetAddress;
 
+import javax.net.ssl.TrustManager;
+
 /**
  * Client configuration options such as proxy settings, user agent string, max
  * retry attempts, etc.
@@ -166,6 +168,11 @@ public class ClientConfiguration {
      */
     private String signerOverride;
 
+    /**
+     * Optional override to control how to perform authentication for secure connections.
+     */
+    private TrustManager trustManager = null;
+
     public ClientConfiguration() {
     }
 
@@ -189,6 +196,7 @@ public class ClientConfiguration {
         this.socketReceiveBufferSizeHint = other.socketReceiveBufferSizeHint;
         this.socketSendBufferSizeHint = other.socketSendBufferSizeHint;
         this.signerOverride = other.signerOverride;
+        this.trustManager = other.trustManager;
     }
 
     /**
@@ -982,6 +990,40 @@ public class ClientConfiguration {
      */
     public ClientConfiguration withPreemptiveBasicProxyAuth(boolean preemptiveBasicProxyAuth) {
         setPreemptiveBasicProxyAuth(preemptiveBasicProxyAuth);
+        return this;
+    }
+
+    /**
+     * Gets the trust manager to use for secure connections from this client.
+     * If null the default authentication will be used.
+     *
+     * @return The trust manager to use for this client, or null to use the default
+     * authentication for secure connections.
+     */
+    public TrustManager getTrustManager() {
+        return trustManager;
+    }
+
+    /**
+     * Sets the trust manager to use for secure connections from this client.
+     * If null the default authentication will be used.
+     *
+     * @param trustManager The trust manager to use for this client.
+     */
+    public void setTrustManager(TrustManager trustManager) {
+        this.trustManager = trustManager;
+    }
+
+    /**
+     * Sets the trust manager to use for secure connections from this client, and returns the
+     * updated ClientConfiguration object so that additional calls may be chained together.
+     * If null the default authentication will be used.
+     *
+     * @param trustManager The trust manager to use for this client.
+     * @return The updated ClientConfiguration object.
+     */
+    public ClientConfiguration withTrustManager(TrustManager trustManager) {
+        setTrustManager(trustManager);
         return this;
     }
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/UrlHttpClient.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/UrlHttpClient.java
@@ -191,12 +191,32 @@ public class UrlHttpClient implements HttpClient {
                 disableCertificateValidation(https);
             }
             */
+
+            if (config.getTrustManager() != null) {
+                enableCustomTrustManager(https);
+            }
         }
     }
 
-    /*
     private SSLContext sc = null;
 
+    private void enableCustomTrustManager(HttpsURLConnection connection) {
+        if (sc == null) {
+            TrustManager[] customTrustManagers = new TrustManager[] {
+                    config.getTrustManager()
+            };
+            try {
+                sc = SSLContext.getInstance("TLS");
+                sc.init(null, customTrustManagers, null);
+            } catch (GeneralSecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        connection.setSSLSocketFactory(sc.getSocketFactory());
+    }
+
+    /*
     private void disableCertificateValidation(HttpsURLConnection connection) {
         if (sc == null) {
             TrustManager[] trustAllCerts = new TrustManager[] {

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import javax.net.ssl.TrustManager;
+
 public class ClientConfigurationTest {
 
     @Test
@@ -119,6 +121,11 @@ public class ClientConfigurationTest {
         c.setUserAgent("set");
         assertEquals(c.getUserAgent(), "set");
 
+        TrustManager trustManager = new TrustManager() {};
+        c.withTrustManager(trustManager);
+        assertSame(trustManager, c.getTrustManager());
+        c.setTrustManager(null);
+        assertNull(c.getTrustManager());
     }
 
     @Test
@@ -143,6 +150,8 @@ public class ClientConfigurationTest {
         c.withSocketBufferSizeHints(0, 1);
         c.withSocketTimeout(0);
         c.withUserAgent("ua");
+        TrustManager trustManager = new TrustManager() {};
+        c.withTrustManager(trustManager);
 
         ClientConfiguration n = new ClientConfiguration(c);
         assertEquals(c.getConnectionTimeout(), n.getConnectionTimeout());
@@ -161,7 +170,8 @@ public class ClientConfigurationTest {
         assertArrayEquals(c.getSocketBufferSizeHints(), n.getSocketBufferSizeHints());
         assertEquals(c.getSocketTimeout(), n.getSocketTimeout());
         assertEquals(c.getUserAgent(), n.getUserAgent());
-
+        assertEquals(c.getUserAgent(), n.getUserAgent());
+        assertSame(c.getTrustManager(), n.getTrustManager());
     }
 
 }


### PR DESCRIPTION
To be able to validate the SSL certificate for a
https connection, to ensure server end point,
allow a custom trust manger to be set on client
configuration.