### PR TITLE
Null check sessionCredentials before saving

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
@@ -452,17 +452,21 @@ public class CognitoCachingCredentialsProvider
             }
         }
 
-        saveCredentials(sessionCredentials,
-                getSessionCredentitalsExpiration().getTime());
+        if (sessionCredentials != null) {
+            saveCredentials(sessionCredentials,
+                    getSessionCredentitalsExpiration().getTime());
+        }
 
         return sessionCredentials;
     }
-    
+
     @Override
     public void refresh() {
         super.refresh();
-        saveCredentials(sessionCredentials,
-                getSessionCredentitalsExpiration().getTime());
+        if (sessionCredentials != null) {
+            saveCredentials(sessionCredentials,
+                    getSessionCredentitalsExpiration().getTime());
+        }
     }
 
     @Override


### PR DESCRIPTION
When saving sessionCredentials a NullPointerException
will happen if sessionCredentials is null.
Null check sessionCredentials before saving.
