### PR TITLE
aws TransferService - supporting alternative NetworkInfoReceiver

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
@@ -67,7 +67,7 @@ class DownloadTask implements Callable<Boolean> {
      */
     @Override
     public Boolean call() throws Exception {
-        if (!networkInfo.isNetworkConnected()) {
+        if (!networkInfo.isNetworkAvailableForTransfer(download)) {
             updater.updateState(download.id, TransferState.WAITING_FOR_NETWORK);
             return false;
         }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeoutException;
  * TransferRecord is used to store all the information of a transfer and
  * start/stop the a thread for the transfer task.
  */
-class TransferRecord {
+public class TransferRecord {
     private static final String TAG = "TransferRecord";
 
     public int id;

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
@@ -65,7 +65,7 @@ class UploadTask implements Callable<Boolean> {
      */
     @Override
     public Boolean call() throws Exception {
-        if (!networkInfo.isNetworkConnected()) {
+        if (!networkInfo.isNetworkAvailableForTransfer(upload)) {
             updater.updateState(upload.id, TransferState.WAITING_FOR_NETWORK);
             return false;
         }
@@ -166,7 +166,7 @@ class UploadTask implements Callable<Boolean> {
                     Log.d(TAG, "Transfer " + upload.id + " is interrupted by user");
                     return false;
                 } else if (e.getCause() != null && e.getCause() instanceof IOException
-                        && !networkInfo.isNetworkConnected()) {
+                        && !networkInfo.isNetworkAvailableForTransfer(upload)) {
                     Log.d(TAG, "Transfer " + upload.id + " waits for network");
                     updater.updateState(upload.id, TransferState.WAITING_FOR_NETWORK);
                 }
@@ -213,7 +213,7 @@ class UploadTask implements Callable<Boolean> {
                 Log.d(TAG, "Transfer " + upload.id + " is interrupted by user");
                 return false;
             } else if (e.getCause() != null && e.getCause() instanceof IOException
-                    && !networkInfo.isNetworkConnected()) {
+                    && !networkInfo.isNetworkAvailableForTransfer(upload)) {
                 Log.d(TAG, "Transfer " + upload.id + " waits for network");
                 updater.updateState(upload.id, TransferState.WAITING_FOR_NETWORK);
             }


### PR DESCRIPTION
allowing library clients to integrate their own NetworkInfoReceiver