### PR TITLE
Ignore null request parameters

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -187,6 +187,10 @@ class ApiClientHandler implements InvocationHandler {
     void processParameter(Request<?> request, Parameter p, Object arg) {
         final String name = p.name();
         final String location = p.location();
+        
+        if (arg == null) {
+        	return;
+        }
 
         if ("header".equals(location)) {
             request.addHeader(name, String.valueOf(arg));


### PR DESCRIPTION
When building requests, skip parameters which value is null.

This avoid having a number of parameters that contains the String
"null". That was particularly annoying with header parameters.
