### PR TITLE
Enforce meaningful User-Agent header values

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientHandler.java
@@ -106,10 +106,11 @@ class ApiClientHandler implements InvocationHandler {
         final Request<?> request = buildRequest(method, args);
 
         final ExecutionContext context = new ExecutionContext();
-        String userAgent = apiName;
+        String userAgent;
         if (request.getHeaders().containsKey("User-Agent")) {
-            // append it to execution context
-            userAgent += " " + request.getHeaders().get("User-Agent");
+            userAgent = request.getHeaders().get("User-Agent");
+        } else {
+        	userAgent = clientConfiguration.getUserAgent();
         }
         context.setContextUserAgent(userAgent);
         return requestFactory.createHttpRequest(request, clientConfiguration, context);
@@ -291,10 +292,11 @@ class ApiClientHandler implements InvocationHandler {
             request.setEndpoint(URI.create(endpoint));
         }
 
-        String userAgent = apiName;
+        String userAgent;
         if (request.getHeaders().containsKey("User-Agent")) {
-            // append it to execution context
-            userAgent += " " + request.getHeaders().get("User-Agent");
+            userAgent = request.getHeaders().get("User-Agent");
+        } else {
+        	userAgent = clientConfiguration.getUserAgent();
         }
         context.setContextUserAgent(userAgent);
 


### PR DESCRIPTION
When setting ExecutionContext user agent, only use current request
user agent header or the value set in the clientConfiguration.

This avoids invalid user agents made up of the interface simple name
or of the request user agent concatenated to the interface simple name.
