### PR TITLE
Bug fix for missing required attribute Exception

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/NewPasswordContinuation.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/NewPasswordContinuation.java
@@ -124,8 +124,9 @@ public class NewPasswordContinuation extends ChallengeContinuation {
     public void continueTask() {
         if (requiredAttributes != null && requiredAttributes.size() > 1) {
             for (String requiredAttribute: requiredAttributes) {
-                if (!challengeResponses.containsKey(requiredAttribute)) {
-                    throw new CognitoParameterInvalidException(String.format("Missing required attribute: ", requiredAttribute));
+				String requiredAttrKey = CognitoServiceConstants.CHLG_PARAM_USER_ATTRIBUTE_PREFIX + requiredAttribute;
+                if (!challengeResponses.containsKey(requiredAttrKey)) {
+                    throw new CognitoParameterInvalidException(String.format("Missing required attribute: %s", requiredAttribute));
                 }
             }
         }


### PR DESCRIPTION
``NewPasswordContinuation#continueTask`` throws ``CognitoParameterInvalidException: Missing required attribute`` even when the required user attributes have been set.