### PR TITLE
cognitoauth: Fix "Unexpected char 0x0a at 82 in header value" Error When Using Client Secret

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/Pkce.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/Pkce.java
@@ -69,6 +69,6 @@ public final class Pkce {
             return null;
         }
         byte[] data = str.getBytes(Charset.forName("ISO-8859-1"));
-        return Base64.encodeToString(data, Base64.DEFAULT);
+        return Base64.encodeToString(data, Base64.NO_WRAP);
     }
 }


### PR DESCRIPTION
This request fixes issue #315, which occurs whenever a client secret is used.

Pkce.encodeBase64() currently uses Base64.DEFAULT when creating the base64-encoded string to be used for the PKCE Authorization header. This breaks the ability to use a client secret, as Base64.DEFAULT adds a newline (0x0a) character at the end of the encoded string, which results in the call to [httpsURLConnection.addRequestProperty() in AuthHttpClient.httpPost()](https://github.com/aws/aws-sdk-android/blob/master/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/AuthHttpClient.java#L55) to throw an exception with a stack trace similar to the following:
```
java.lang.IllegalArgumentException: Unexpected char 0x0a at 82 in header value: Basic M20zbG5majcxaDljYzZqamk5ajdmZDVndWM6NGxqaXZjdWYzMDlvNWM4NGhrNnYzc28zZDFnajdxNGZpN2lnM2R2aDdzdnY2MWp1Y3Iy
   at com.android.okhttp.Headers$Builder.checkNameAndValue(Headers.java:313)
   at com.android.okhttp.Headers$Builder.add(Headers.java:245)
   at com.android.okhttp.internal.huc.HttpURLConnectionImpl.addRequestProperty(HttpURLConnectionImpl.java:579)
   at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.addRequestProperty(DelegatingHttpsURLConnection.java:186)
   at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.addRequestProperty(HttpsURLConnectionImpl.java)
   at com.amazonaws.mobileconnectors.cognitoauth.util.AuthHttpClient.httpPost(AuthHttpClient.java:56)
   at com.amazonaws.mobileconnectors.cognitoauth.AuthClient$1.run(AuthClient.java:290)
   at java.lang.Thread.run(Thread.java:761)
```
