### PR TITLE
fix issues: transfer state change issue

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -171,6 +171,13 @@ class TransferRecord {
             }
             return true;
         }
+        /*
+         * @Anchorer
+         * if transfer is already completed when trying to start, we should update state and trigger a callback
+         */
+        if (TransferState.COMPLETED.equals(state)) {
+            updater.updateState(id, TransferState.COMPLETED);
+        }
         return false;
     }
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -171,10 +171,7 @@ class TransferRecord {
             }
             return true;
         }
-        /*
-         * @Anchorer
-         * if transfer is already completed when trying to start, we should update state and trigger a callback
-         */
+        // if transfer is already completed when trying to start, we should update state and trigger a callback
         if (TransferState.COMPLETED.equals(state)) {
             updater.updateState(id, TransferState.COMPLETED);
         }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
@@ -319,6 +319,11 @@ public class TransferService extends Service {
                 transfer = dbUtil.getTransferById(id);
                 if (transfer != null) {
                     updater.addTransfer(transfer);
+                    /*
+                     * @Anchorer
+                     * while resuming a transfer, if the transfer is null, create a new one, and trigger a state callback instantly. (for UI display)
+                     */
+                    updater.updateState(id, transfer.state);
                 } else {
                     LOGGER.error("Can't find transfer: " + id);
                 }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
@@ -319,10 +319,7 @@ public class TransferService extends Service {
                 transfer = dbUtil.getTransferById(id);
                 if (transfer != null) {
                     updater.addTransfer(transfer);
-                    /*
-                     * @Anchorer
-                     * while resuming a transfer, if the transfer is null, create a new one, and trigger a state callback instantly. (for UI display)
-                     */
+                    //while resuming a transfer, if the transfer is null, create a new one, and trigger a state callback instantly. (for UI display)
                     updater.updateState(id, transfer.state);
                 } else {
                     LOGGER.error("Can't find transfer: " + id);

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
@@ -106,10 +106,7 @@ class UploadTask implements Callable<Boolean> {
                         + " due to " + ace.getMessage(), ace);
                 updater.throwError(upload.id, ace);
 
-                /*
-                 * @Anchorer
-                 * While initiating Multi-part upload, if the task is already paused by user, the task should not be set to FAILED.
-                 */
+                // While initiating Multi-part upload, if the task is already paused by user, the task should not be set to FAILED.
                 if (!TransferState.PAUSED.equals(upload.state)) {
                     updater.updateState(upload.id, TransferState.FAILED);
                 }
@@ -191,10 +188,7 @@ class UploadTask implements Callable<Boolean> {
                 updater.throwError(upload.id, e);
             }
 
-            /*
-             * @Anchorer
-             * If the task is already paused by user, it should not be set to FAILED state.
-             */
+            // If the task is already paused by user, it should not be set to FAILED state.
             if (!TransferState.PAUSED.equals(upload.state)) {
                 updater.updateState(upload.id, TransferState.FAILED);
             }
@@ -212,10 +206,7 @@ class UploadTask implements Callable<Boolean> {
                     + " due to " + ace.getMessage(), ace);
             updater.throwError(upload.id, ace);
 
-            /*
-             * @Anchorer
-             * If the task is already paused by user, it should not be set to FAILED state.
-             */
+            // If the task is already paused by user, it should not be set to FAILED state.
             if (!TransferState.PAUSED.equals(upload.state)) {
                 updater.updateState(upload.id, TransferState.FAILED);
             }
@@ -259,10 +250,7 @@ class UploadTask implements Callable<Boolean> {
             LOGGER.debug("Failed to upload: " + upload.id + " due to " + e.getMessage(), e);
             updater.throwError(upload.id, e);
 
-            /*
-             * @Anchorer
-             * If the task is already paused by user, it should not be set to FAILED state.
-             */
+            // If the task is already paused by user, it should not be set to FAILED state.
             if (!TransferState.PAUSED.equals(upload.state)) {
                 updater.updateState(upload.id, TransferState.FAILED);
             }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
@@ -105,7 +105,14 @@ class UploadTask implements Callable<Boolean> {
                 LOGGER.error("Error initiating multipart upload: " + upload.id
                         + " due to " + ace.getMessage(), ace);
                 updater.throwError(upload.id, ace);
-                updater.updateState(upload.id, TransferState.FAILED);
+
+                /*
+                 * @Anchorer
+                 * While initiating Multi-part upload, if the task is already paused by user, the task should not be set to FAILED.
+                 */
+                if (!TransferState.PAUSED.equals(upload.state)) {
+                    updater.updateState(upload.id, TransferState.FAILED);
+                }
                 return false;
             }
             dbUtil.updateMultipartId(upload.id, upload.multipartId);
@@ -183,7 +190,14 @@ class UploadTask implements Callable<Boolean> {
                 }
                 updater.throwError(upload.id, e);
             }
-            updater.updateState(upload.id, TransferState.FAILED);
+
+            /*
+             * @Anchorer
+             * If the task is already paused by user, it should not be set to FAILED state.
+             */
+            if (!TransferState.PAUSED.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.FAILED);
+            }
             return false;
         }
 
@@ -197,7 +211,14 @@ class UploadTask implements Callable<Boolean> {
             LOGGER.error("Failed to complete multipart: " + upload.id
                     + " due to " + ace.getMessage(), ace);
             updater.throwError(upload.id, ace);
-            updater.updateState(upload.id, TransferState.FAILED);
+
+            /*
+             * @Anchorer
+             * If the task is already paused by user, it should not be set to FAILED state.
+             */
+            if (!TransferState.PAUSED.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.FAILED);
+            }
             return false;
         }
     }
@@ -237,7 +258,14 @@ class UploadTask implements Callable<Boolean> {
             // all other exceptions
             LOGGER.debug("Failed to upload: " + upload.id + " due to " + e.getMessage(), e);
             updater.throwError(upload.id, e);
-            updater.updateState(upload.id, TransferState.FAILED);
+
+            /*
+             * @Anchorer
+             * If the task is already paused by user, it should not be set to FAILED state.
+             */
+            if (!TransferState.PAUSED.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.FAILED);
+            }
             return false;
         }
     }


### PR DESCRIPTION
This pull request solves two issues.

1. Solve issue #308. I submitted this issue months ago and it still exists in current SDK 

This issue happens when a upload transfer is failed, if the transfer is already paused by user, it still changes state to FAILED. That is incorrect. This issue happens if:  

* Pause a new-created upload transfer while initiating multi-part upload. SDK throws a thread interrupted AmazonClientException and change transfer state to FAILED. 
* Pause a upload transfer while completing multi-part upload. Also throws an Exception and change transfer state to FAILED.

I modified UploadTask.java and check state before setting transfer state to FAILED.

2. Second issue is related to transfer state callback. 

* When trying to resume a already-failed upload transfer, no IN_PROGRESS state change callback is triggered. 
* When trying to resume a already-completed upload transfer, no COMPLETED state change callback is triggered.

I have comments in my code.
