### PR TITLE
fix some errors in RestUtils.java

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RestUtils.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RestUtils.java
@@ -171,6 +171,7 @@ public class RestUtils {
                 new String[request.getParameters().size()]);
         Arrays.sort(parameterNames);
         char separator = '?';
+        boolean first = true;
         for (final String parameterName : parameterNames) {
             // Skip any parameters that aren't part of the canonical signed
             // string
@@ -180,11 +181,16 @@ public class RestUtils {
                  !additionalQueryParamsToSign.contains(parameterName))
             ) {
                 continue;
+            }      
+            
+            if(first) {
+            	buf.append(separator);
+            	first = false;
             }
-            if (buf.length() == 0) {
-                buf.append(separator);
+            else {
+                buf.append('&');
             }
-
+  
             buf.append(parameterName);
             final String parameterValue = request.getParameters().get(parameterName);
             if (parameterValue != null) {


### PR DESCRIPTION
The question mark is used when we use the multipartupload function. And it’s meaning to add the question mark in the function, but the condition is impossible, because the buf is not null. Other than, the character '&' should be added into the string, but in the function the variable separator is not used actually.