### PR TITLE
Add missing dependency in AWSIotMqttManager

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -47,6 +47,7 @@ import java.security.UnrecoverableKeyException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.SocketFactory;
 


### PR DESCRIPTION
The PR merge for ConcurrentHashMap removed the import for Map. Added it back in `AWSIotMqttManager`.