### PR TITLE
Cognito: Send secret hash during USER_PASSWORD authentication.

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
@@ -2604,6 +2604,8 @@ public class CognitoUser {
                 authenticationDetails.getUserId());
         authRequest.addAuthParametersEntry(CognitoServiceConstants.AUTH_PARAM_PASSWORD,
                 authenticationDetails.getPassword());
+        authRequest.addAuthParametersEntry(CognitoServiceConstants.AUTH_PARAM_SECRET_HASH,
+                secretHash);
 
         if (authenticationDetails.getValidationData() != null
                 && authenticationDetails.getValidationData().size() > 0) {


### PR DESCRIPTION
### Problem

CognitoUser.getSession initiated with "USER_PASSWORD" authentication type does not send secret hash with the in auth request which leads to: "NotAuthorizedException: Unable to verify secret hash for client".

### Original Issue

https://github.com/aws/aws-sdk-android/issues/484



