### PR TITLE
change the code pool.getAppWebDomain to pool.getAppId to fix the issu…

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -203,8 +203,9 @@ public class AuthClient {
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     public boolean isAuthenticated() {
+        //change the code pool.getAppWebDomain to pool.getAppId to fix the issue that isAuthenticated return false for logged user
         AuthUserSession session =
-                LocalDataManager.getCachedSession(context, pool.getAppWebDomain(), userId, pool.getScopes());
+                LocalDataManager.getCachedSession(context, pool.getAppId(), userId, pool.getScopes());
         return session.isValidForThreshold();
     }
 


### PR DESCRIPTION
## Description
 This change is to fix the issue that isAuthenticated return false for logged user.

## Motivation and Context

This change is to fix the issue reported by https://github.com/aws/aws-sdk-android/issues/508


## Test Cases
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- before signed in, isAuthenticated  return false. 
- after signed in, isAuthenticated  return true  
- after signed out, isAuthenticated  return false. 
 


